### PR TITLE
Add support of `patch` HTTP method

### DIFF
--- a/lib/etsy/base_request.rb
+++ b/lib/etsy/base_request.rb
@@ -41,6 +41,10 @@ module Etsy
       raise NotImplementedError
     end
 
+    def patch
+      raise NotImplementedError
+    end
+
     def delete
       raise NotImplementedError
     end

--- a/lib/etsy/request.rb
+++ b/lib/etsy/request.rb
@@ -27,6 +27,11 @@ module Etsy
         Response.call(request.put, api_version: request.api_version)
       end
 
+      def patch(resource_path, parameters = {})
+        request = Request.new(resource_path, parameters)
+        Response.call(request.patch, api_version: request.api_version)
+      end
+
       def delete(resource_path, parameters = {})
         request = Request.new(resource_path, parameters)
         Response.call(request.delete, api_version: request.api_version)
@@ -54,6 +59,7 @@ module Etsy
                    :base_path,
                    :post,
                    :put,
+                   :patch,
                    :delete,
                    :client,
                    :query,

--- a/lib/etsy/v3/request.rb
+++ b/lib/etsy/v3/request.rb
@@ -28,6 +28,10 @@ module Etsy
         make_request(:put, resource_path, body: @parameters)
       end
 
+      def patch
+        make_request(:patch, resource_path, body: @parameters)
+      end
+
       def post
         make_request(:post, resource_path, body: @parameters)
       end

--- a/test/unit/etsy/v3/request_test.rb
+++ b/test/unit/etsy/v3/request_test.rb
@@ -111,6 +111,40 @@ module Etsy
           end
         end
 
+        context 'when \'patch\' requested' do
+          should 'call \'patch\' of the oauth token object' do
+            with_etsy_app_keys(api_key: 'api_key_X', api_secret: 'api_secret_X') do
+              params = [
+                '/shops/1/listings/1',
+                {
+                  access_token: 'client_token',
+                  description: 'updated description'
+                }
+              ]
+
+              request        = Etsy::V3::Request.new(*params)
+              client         = request.client
+              oauth_response = stub()
+              response       = stub()
+
+              oauth_response
+                .stubs(:response)
+                .returns(response)
+
+              client
+                .expects(:patch)
+                .with(
+                  'shops/1/listings/1',
+                  body: { description: 'updated description' },
+                  headers: { 'x-api-key' => 'api_key_X' }
+                )
+                .returns(oauth_response)
+
+              request.patch.should == response
+            end
+          end
+        end
+
         context 'when \'post\' requested' do
           should 'call \'post\' of the oauth token object' do
             with_etsy_app_keys(api_key: 'api_key_X', api_secret: 'api_secret_X') do

--- a/test/unit/etsy/v3/request_test.rb
+++ b/test/unit/etsy/v3/request_test.rb
@@ -217,8 +217,8 @@ module Etsy
           should 'have default options' do
             with_etsy_app_keys(api_key: 'api_key_X', api_secret: 'api_secret_X', user_agent: 'TestApp') do
               expected_options = {
-                token_url: '/oauth/token',
-                authorize_url: '/oauth/authorize',
+                token_url: 'oauth/token',
+                authorize_url: 'oauth/authorize',
                 max_redirects: 5,
                 token_method: :post,
                 raise_errors: false,


### PR DESCRIPTION
## Problem

Etsy API is switching some endpoints from `PUT` to `PATCH`. Source: https://github.com/etsy/open-api/discussions/1392
`PATCH` is currently not supported in the gem.

## Solution

This PR adds support of `PATCH` HTTP method to the gem.
Adding only to V3 as V2 is no longer supported.