### PR TITLE
VQCI-6957 Updated x-api-key use shared secret

### DIFF
--- a/lib/etsy.rb
+++ b/lib/etsy.rb
@@ -104,7 +104,7 @@ module Etsy
   end
 
   def self.shared_secret=(secret)
-    @shared_secret ||= secret
+    @shared_secret = secret
     Thread.current[:etsy_shared_secret] = secret
   end
 

--- a/lib/etsy.rb
+++ b/lib/etsy.rb
@@ -99,6 +99,15 @@ module Etsy
     Thread.current[:etsy_api_secret] = secret
   end
 
+  def self.shared_secret
+    Thread.current[:etsy_shared_secret] || @shared_secret
+  end
+
+  def self.shared_secret=(secret)
+    @shared_secret ||= secret
+    Thread.current[:etsy_shared_secret] = secret
+  end
+
   SANDBOX_HOST = 'sandbox.openapi.etsy.com'
   PRODUCTION_HOST = 'openapi.etsy.com'
 

--- a/lib/etsy/v3/request.rb
+++ b/lib/etsy/v3/request.rb
@@ -69,7 +69,8 @@ module Etsy
       end
 
       def api_key_header
-        { 'x-api-key' => Etsy.api_key }
+        api_key_value = Etsy.shared_secret ? "#{Etsy.api_key}:#{Etsy.shared_secret}" : Etsy.api_key
+        { 'x-api-key' => api_key_value }
       end
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -49,19 +49,22 @@ class Test::Unit::TestCase
     objects
   end
 
-  def with_etsy_app_keys(api_key:, api_secret:, user_agent: nil)
-    original_api_key    = Etsy.api_key
-    original_api_secret = Etsy.api_secret
-    original_user_agent = Etsy.user_agent
+  def with_etsy_app_keys(api_key:, api_secret:, user_agent: nil, shared_secret: nil)
+    original_api_key       = Etsy.api_key
+    original_api_secret    = Etsy.api_secret
+    original_user_agent    = Etsy.user_agent
+    original_shared_secret = Etsy.shared_secret
 
-    Etsy.api_key    = 'api_key_X'
-    Etsy.api_secret = 'api_secret_X'
-    Etsy.user_agent = user_agent || original_user_agent
+    Etsy.api_key       = 'api_key_X'
+    Etsy.api_secret    = 'api_secret_X'
+    Etsy.user_agent    = user_agent || original_user_agent
+    Etsy.shared_secret = shared_secret
 
     yield
-
-    Etsy.api_key    = original_api_key
-    Etsy.api_secret = original_api_secret
-    Etsy.user_agent = original_user_agent
+  ensure
+    Etsy.api_key       = original_api_key
+    Etsy.api_secret    = original_api_secret
+    Etsy.user_agent    = original_user_agent
+    Etsy.shared_secret = original_shared_secret
   end
 end

--- a/test/unit/etsy/v3/request_test.rb
+++ b/test/unit/etsy/v3/request_test.rb
@@ -3,11 +3,6 @@ require File.expand_path('../../../../test_helper', __FILE__)
 module Etsy
   module V3
     class RequestTest < Test::Unit::TestCase
-      def setup
-        Etsy.shared_secret = nil
-        Thread.current[:etsy_shared_secret] = nil
-      end
-
       context 'when v2 params passed for initialization' do
         should 'strip them from parameters' do
           v3_request_params = {

--- a/test/unit/etsy/v3/request_test.rb
+++ b/test/unit/etsy/v3/request_test.rb
@@ -3,6 +3,11 @@ require File.expand_path('../../../../test_helper', __FILE__)
 module Etsy
   module V3
     class RequestTest < Test::Unit::TestCase
+      def setup
+        Etsy.shared_secret = nil
+        Thread.current[:etsy_shared_secret] = nil
+      end
+
       context 'when v2 params passed for initialization' do
         should 'strip them from parameters' do
           v3_request_params = {
@@ -70,6 +75,34 @@ module Etsy
               client
                 .expects(:get)
                 .with('shops/1/listings', params: { state: 'active' }, headers: { 'x-api-key' => 'api_key_X' })
+                .returns(oauth_response)
+
+              request.get.should == response
+            end
+          end
+
+          should 'include shared secret in x-api-key header when set' do
+            with_etsy_app_keys(api_key: 'api_key_X', api_secret: 'api_secret_X', shared_secret: 'shared_secret_X') do
+              params = [
+                '/shops/1/listings',
+                {
+                  access_token: 'client_token',
+                  state: 'active'
+                }
+              ]
+
+              request        = Etsy::V3::Request.new(*params)
+              client         = request.client
+              oauth_response = stub()
+              response       = stub()
+
+              oauth_response
+                .stubs(:response)
+                .returns(response)
+
+              client
+                .expects(:get)
+                .with('shops/1/listings', params: { state: 'active' }, headers: { 'x-api-key' => 'api_key_X:shared_secret_X' })
                 .returns(oauth_response)
 
               request.get.should == response

--- a/test/unit/etsy_test.rb
+++ b/test/unit/etsy_test.rb
@@ -11,6 +11,7 @@ class EtsyTest < Test::Unit::TestCase
       Etsy.instance_variable_set(:@host, nil)
       Etsy.instance_variable_set(:@api_key, nil)
       Etsy.instance_variable_set(:@api_secret, nil)
+      Etsy.instance_variable_set(:@shared_secret, nil)
       Etsy.instance_variable_set(:@permission_scopes, nil)
       Etsy.instance_variable_set(:@silent_errors, nil)
     end
@@ -55,7 +56,27 @@ class EtsyTest < Test::Unit::TestCase
       end.join
     end
 
-    should "be able to find a user by username" do
+    should "be able to set and retrieve the shared secret" do
+      Etsy.shared_secret = 'shared_secret'
+      Etsy.shared_secret.should == 'shared_secret'
+    end
+
+    should "be able to set and retrieve the shared secret across threads (global)" do
+      Etsy.shared_secret = 'shared_secret'
+      Thread.new do
+        Etsy.shared_secret.should == 'shared_secret'
+      end.join
+    end
+
+    should "be able to set and retrieve the shared secret inside a thread (thread local)" do
+      Etsy.shared_secret = 'shared_secret'
+      Thread.new do
+        Etsy.shared_secret = 'thread_local_shared_secret'
+        Etsy.shared_secret.should == 'thread_local_shared_secret'
+      end.join
+    end
+
+    should 'be able to find a user by username' do
       user = stub()
 
       Etsy::User.expects(:find).with('littletjane').returns(user)


### PR DESCRIPTION
Ticket : https://sim.amazon.com/issues/VQCI-6957

Updated x-api-key header to new format api key header, since etsy will stop supporting old format from 18th Jan 2026.